### PR TITLE
Fixed compilation in recent Golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The strftime function and string pattern matching is currently copied from [yuin
 package main
 
 import (
-	"ofunc/lua/util"
+	"github.com/ofunc/lua/util"
 )
 
 func main() {

--- a/compile.go
+++ b/compile.go
@@ -22,7 +22,7 @@ misrepresented as being the original software.
 
 package lua
 
-import "ofunc/lua/ast"
+import "github.com/ofunc/lua/ast"
 import "fmt"
 
 //import "runtime"

--- a/compile_expr.go
+++ b/compile_expr.go
@@ -22,7 +22,7 @@ misrepresented as being the original software.
 
 package lua
 
-import "ofunc/lua/ast"
+import "github.com/ofunc/lua/ast"
 
 // TODO: It is possible to have more constants than can be fit into an Bx field, in which case a
 // LOADKX instruction should be used.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ofunc/lua
+
+go 1.21.1

--- a/lmodbase/mod.go
+++ b/lmodbase/mod.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 const (

--- a/lmodio/mod.go
+++ b/lmodio/mod.go
@@ -30,7 +30,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 // Open opens the module.

--- a/lmodio/util.go
+++ b/lmodio/util.go
@@ -25,7 +25,7 @@ package lmodio
 import (
 	"io"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 func toReader(l *lua.State, i int) io.Reader {

--- a/lmodjs/meta.go
+++ b/lmodjs/meta.go
@@ -27,7 +27,7 @@ package lmodjs
 import (
 	"syscall/js"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 func jsmeta(l *lua.State) int {

--- a/lmodjs/mod.go
+++ b/lmodjs/mod.go
@@ -28,7 +28,7 @@ package lmodjs
 import (
 	"syscall/js"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 // Open opens the module.
@@ -93,7 +93,7 @@ func lNew(l *lua.State) int {
 
 func lFree(l *lua.State) int {
 	if v, ok := l.GetRaw(1).(js.Value); ok {
-		if x := v.Get(LuaKey); x != undefined && x != null {
+		if x := v.Get(LuaKey); !(x.IsUndefined() || x.IsNull()) {
 			id := x.Int()
 			l.Push(RegistryKey)
 			l.GetTableRaw(lua.RegistryIndex)

--- a/lmodjs/util.go
+++ b/lmodjs/util.go
@@ -27,7 +27,7 @@ package lmodjs
 import (
 	"syscall/js"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 // Registry key

--- a/lmodmath/mod.go
+++ b/lmodmath/mod.go
@@ -27,7 +27,7 @@ import (
 	"math/rand"
 	"time"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 func init() {

--- a/lmodos/file.go
+++ b/lmodos/file.go
@@ -25,7 +25,7 @@ package lmodos
 import (
 	"os"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 func matefile(l *lua.State) int {

--- a/lmodos/info.go
+++ b/lmodos/info.go
@@ -25,7 +25,7 @@ package lmodos
 import (
 	"os"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 func metainfo(l *lua.State) int {

--- a/lmodos/mod.go
+++ b/lmodos/mod.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"time"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 // The root path for the executable.

--- a/lmodos/prog.go
+++ b/lmodos/prog.go
@@ -26,7 +26,7 @@ import (
 	"io"
 	"os/exec"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 type prog struct {

--- a/lmodstring/gsub.go
+++ b/lmodstring/gsub.go
@@ -27,8 +27,8 @@ package lmodstring
 import (
 	"fmt"
 
-	"ofunc/lua"
-	"ofunc/lua/lmodstring/pm"
+	"github.com/ofunc/lua"
+	"github.com/ofunc/lua/lmodstring/pm"
 )
 
 func gsubstr(l *lua.State, str string, matches []*pm.MatchData) string {

--- a/lmodstring/mod.go
+++ b/lmodstring/mod.go
@@ -26,8 +26,8 @@ import (
 	"fmt"
 	"strings"
 
-	"ofunc/lua"
-	"ofunc/lua/lmodstring/pm"
+	"github.com/ofunc/lua"
+	"github.com/ofunc/lua/lmodstring/pm"
 )
 
 // Open opens the module.

--- a/lmodtable/mod.go
+++ b/lmodtable/mod.go
@@ -26,7 +26,7 @@ import (
 	"sort"
 	"strings"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 // Open opens the module.

--- a/lmodtable/sorter.go
+++ b/lmodtable/sorter.go
@@ -23,7 +23,7 @@ misrepresented as being the original software.
 package lmodtable
 
 import (
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 type sorter lua.State

--- a/lmodutf8/iter.go
+++ b/lmodutf8/iter.go
@@ -25,7 +25,7 @@ package lmodutf8
 import (
 	"unicode/utf8"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 func index(l *lua.State, n, i, j int) (int, int) {

--- a/lmodutf8/mod.go
+++ b/lmodutf8/mod.go
@@ -26,7 +26,7 @@ import (
 	"strconv"
 	"unicode/utf8"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 // Open opens the module.

--- a/lua_test.go
+++ b/lua_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"ofunc/lua"
-	"ofunc/lua/util"
+	"github.com/ofunc/lua"
+	"github.com/ofunc/lua/util"
 )
 
 func TestMain(m *testing.M) {

--- a/util/test.go
+++ b/util/test.go
@@ -29,7 +29,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"ofunc/lua"
+	"github.com/ofunc/lua"
 )
 
 // Test runs the specified test script file.

--- a/util/util.go
+++ b/util/util.go
@@ -26,9 +26,9 @@ package util
 import (
 	"fmt"
 
-	"ofunc/lua"
-	"ofunc/lua/lmodbase"
-	"ofunc/lua/lmodos"
+	"github.com/ofunc/lua"
+	"github.com/ofunc/lua/lmodbase"
+	"github.com/ofunc/lua/lmodos"
 )
 
 const (

--- a/util/util_com.go
+++ b/util/util_com.go
@@ -25,14 +25,14 @@ misrepresented as being the original software.
 package util
 
 import (
-	"ofunc/lua"
-	"ofunc/lua/lmodbase"
-	"ofunc/lua/lmodio"
-	"ofunc/lua/lmodmath"
-	"ofunc/lua/lmodos"
-	"ofunc/lua/lmodstring"
-	"ofunc/lua/lmodtable"
-	"ofunc/lua/lmodutf8"
+	"github.com/ofunc/lua"
+	"github.com/ofunc/lua/lmodbase"
+	"github.com/ofunc/lua/lmodio"
+	"github.com/ofunc/lua/lmodmath"
+	"github.com/ofunc/lua/lmodos"
+	"github.com/ofunc/lua/lmodstring"
+	"github.com/ofunc/lua/lmodtable"
+	"github.com/ofunc/lua/lmodutf8"
 )
 
 // Open opens the buildin modules.

--- a/util/util_js.go
+++ b/util/util_js.go
@@ -25,15 +25,15 @@ misrepresented as being the original software.
 package util
 
 import (
-	"ofunc/lua"
-	"ofunc/lua/lmodbase"
-	"ofunc/lua/lmodio"
-	"ofunc/lua/lmodjs"
-	"ofunc/lua/lmodmath"
-	"ofunc/lua/lmodos"
-	"ofunc/lua/lmodstring"
-	"ofunc/lua/lmodtable"
-	"ofunc/lua/lmodutf8"
+	"github.com/ofunc/lua"
+	"github.com/ofunc/lua/lmodbase"
+	"github.com/ofunc/lua/lmodio"
+	"github.com/ofunc/lua/lmodjs"
+	"github.com/ofunc/lua/lmodmath"
+	"github.com/ofunc/lua/lmodos"
+	"github.com/ofunc/lua/lmodstring"
+	"github.com/ofunc/lua/lmodtable"
+	"github.com/ofunc/lua/lmodutf8"
 )
 
 // Open opens the buildin modules.


### PR DESCRIPTION
Fixed compilation due to enforcement of module mode in recent Golang versions.
Fixed comparison issue in `lmodjs.lFree()`.

BTW Thank you @erdian718 for this feature-rich project!